### PR TITLE
Add missing server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+require('dotenv').config();
+const express = require('express');
+const bodyParser = require('body-parser');
+const mongoose = require('mongoose');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/egoecho';
+
+app.use(bodyParser.json());
+
+async function startServer() {
+  try {
+    await mongoose.connect(MONGODB_URI);
+    console.log('Connected to MongoDB');
+
+    app.get('/', (req, res) => {
+      res.json({ status: 'ok' });
+    });
+
+    app.listen(PORT, () => {
+      console.log(`Server running on port ${PORT}`);
+    });
+  } catch (err) {
+    console.error('Failed to start server:', err);
+    process.exit(1);
+  }
+}
+
+startServer();


### PR DESCRIPTION
## Summary
- add a minimal `server.js` that starts an Express server and connects to MongoDB

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885c317f404832ca963efe1731719ba