### PR TITLE
Implement basic API skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+PORT=3000
+MONGODB_URI=mongodb://localhost:27017/egoecho
+JWT_SECRET=your_jwt_secret
+AES_SECRET=your_aes_secret

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # 환경변수
 .env
 .env.*
+!.env.example
 
 # 로그 및 디버그 파일
 npm-debug.log*

--- a/models/Diary.js
+++ b/models/Diary.js
@@ -1,0 +1,17 @@
+const mongoose = require('mongoose');
+
+const diarySchema = new mongoose.Schema({
+  diaryId: { type: Number, required: true, unique: true },
+  userId: { type: String, required: true },
+  writeDate: { type: String, required: true }, // YYYYMMDD
+  writeTime: { type: String, required: true }, // HHmm
+  title: { type: String, required: true },
+  content: { type: String, required: true },
+  aiScore: { type: Number },
+  aiReview: { type: String },
+  createdAt: { type: Date, default: Date.now }
+});
+
+diarySchema.index({ userId: 1, writeDate: 1 }, { unique: true });
+
+module.exports = mongoose.model('Diary', diarySchema);

--- a/models/LoginLog.js
+++ b/models/LoginLog.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const loginLogSchema = new mongoose.Schema({
+  userId: { type: String, required: true },
+  loginAt: { type: Date, default: Date.now },
+  ipAddress: { type: String },
+  userAgent: { type: String }
+});
+
+module.exports = mongoose.model('LoginLog', loginLogSchema);

--- a/models/Media.js
+++ b/models/Media.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const mediaSchema = new mongoose.Schema({
+  diaryId: { type: Number, required: true },
+  userId: { type: String, required: true },
+  writeDate: { type: String, required: true },
+  mediaId: { type: String, required: true },
+  mediaType: { type: String, enum: ['image', 'youtube'], required: true },
+  mediaData: { type: String, required: true },
+  uploadedAt: { type: Date, default: Date.now }
+});
+
+mediaSchema.index({ diaryId: 1, mediaId: 1 }, { unique: true });
+
+module.exports = mongoose.model('Media', mediaSchema);

--- a/models/User.js
+++ b/models/User.js
@@ -1,0 +1,30 @@
+const mongoose = require('mongoose');
+const crypto = require('crypto');
+
+const userSchema = new mongoose.Schema({
+  userId: { type: String, required: true, unique: true },
+  passwordHash: { type: String, required: true },
+  nickname: { type: String, required: true },
+  encryptedGeminiKey: { type: String },
+  delYn: { type: Boolean, default: false },
+  useYn: { type: Boolean, default: true },
+  loginFailCount: { type: Number, default: 0 },
+  createdAt: { type: Date, default: Date.now }
+});
+
+userSchema.methods.setPassword = function(password) {
+  this.passwordHash = crypto
+    .createHash('sha256')
+    .update(password)
+    .digest('hex');
+};
+
+userSchema.methods.validatePassword = function(password) {
+  const hash = crypto
+    .createHash('sha256')
+    .update(password)
+    .digest('hex');
+  return this.passwordHash === hash;
+};
+
+module.exports = mongoose.model('User', userSchema);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "crypto": "^1.0.1",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
-    "mongoose": "^8.16.5"
+    "mongoose": "^8.16.5",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/routes/analyze.js
+++ b/routes/analyze.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const router = express.Router();
+const jwt = require('jsonwebtoken');
+
+function auth(req, res, next) {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    req.user = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    next();
+  } catch {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+router.post('/', auth, (req, res) => {
+  const { content } = req.body;
+  const aiScore = Math.floor(Math.random() * 101);
+  const aiReview = `감정 점수는 ${aiScore}점입니다. 오늘도 수고하셨어요! 🙂`;
+  res.json({ aiScore, aiReview });
+});
+
+module.exports = router;

--- a/routes/diary.js
+++ b/routes/diary.js
@@ -1,0 +1,47 @@
+const express = require('express');
+const router = express.Router();
+const jwt = require('jsonwebtoken');
+const Diary = require('../models/Diary');
+const Media = require('../models/Media');
+
+function auth(req, res, next) {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    req.user = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    next();
+  } catch {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+let diaryCounter = 1;
+
+router.post('/', auth, async (req, res) => {
+  try {
+    const { title, content } = req.body;
+    const writeDate = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    const writeTime = new Date().toISOString().slice(11, 16).replace(':', '');
+    const diary = new Diary({
+      diaryId: diaryCounter++,
+      userId: req.user.userId,
+      writeDate,
+      writeTime,
+      title,
+      content
+    });
+    await diary.save();
+    res.json({ diaryId: diary.diaryId });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.get('/:diaryId', auth, async (req, res) => {
+  const diary = await Diary.findOne({ diaryId: req.params.diaryId, userId: req.user.userId });
+  if (!diary) return res.status(404).json({ error: 'Not found' });
+  const media = await Media.find({ diaryId: diary.diaryId });
+  res.json({ diary, media });
+});
+
+module.exports = router;

--- a/routes/media.js
+++ b/routes/media.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const router = express.Router();
+const jwt = require('jsonwebtoken');
+const Media = require('../models/Media');
+
+function auth(req, res, next) {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    req.user = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    next();
+  } catch {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+router.post('/image', auth, async (req, res) => {
+  const { diaryId, mediaId, base64 } = req.body;
+  await Media.create({
+    diaryId,
+    userId: req.user.userId,
+    writeDate: new Date().toISOString().slice(0, 10).replace(/-/g, ''),
+    mediaId,
+    mediaType: 'image',
+    mediaData: base64
+  });
+  res.json({ success: true });
+});
+
+router.post('/youtube', auth, async (req, res) => {
+  const { diaryId, mediaId, url } = req.body;
+  await Media.create({
+    diaryId,
+    userId: req.user.userId,
+    writeDate: new Date().toISOString().slice(0, 10).replace(/-/g, ''),
+    mediaId,
+    mediaType: 'youtube',
+    mediaData: url
+  });
+  res.json({ success: true });
+});
+
+module.exports = router;

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,0 +1,63 @@
+const express = require('express');
+const router = express.Router();
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+const LoginLog = require('../models/LoginLog');
+const { encrypt } = require('../utils/encryption');
+
+function createToken(userId) {
+  return jwt.sign({ userId }, process.env.JWT_SECRET || 'secret', { expiresIn: '1h' });
+}
+
+router.post('/register', async (req, res) => {
+  try {
+    const { userId, password, nickname } = req.body;
+    const user = new User({ userId, nickname });
+    user.setPassword(password);
+    await user.save();
+    res.json({ success: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  const { userId, password } = req.body;
+  const user = await User.findOne({ userId });
+  if (!user || !user.validatePassword(password)) {
+    if (user) {
+      user.loginFailCount += 1;
+      await user.save();
+    }
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+
+  user.loginFailCount = 0;
+  await user.save();
+
+  await LoginLog.create({
+    userId: user.userId,
+    ipAddress: req.ip,
+    userAgent: req.get('User-Agent')
+  });
+
+  const token = createToken(user.userId);
+  res.json({ token });
+});
+
+router.patch('/gemini-key', async (req, res) => {
+  const token = req.headers.authorization?.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    const user = await User.findOne({ userId: payload.userId });
+    if (!user) return res.status(404).json({ error: 'User not found' });
+    const { geminiKey } = req.body;
+    user.encryptedGeminiKey = encrypt(geminiKey);
+    await user.save();
+    res.json({ success: true });
+  } catch (err) {
+    res.status(401).json({ error: 'Unauthorized' });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -3,6 +3,11 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const mongoose = require('mongoose');
 
+const userRoutes = require('./routes/user');
+const diaryRoutes = require('./routes/diary');
+const mediaRoutes = require('./routes/media');
+const analyzeRoutes = require('./routes/analyze');
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/egoecho';
@@ -13,6 +18,11 @@ async function startServer() {
   try {
     await mongoose.connect(MONGODB_URI);
     console.log('Connected to MongoDB');
+
+    app.use('/api/user', userRoutes);
+    app.use('/api/diary', diaryRoutes);
+    app.use('/api/media', mediaRoutes);
+    app.use('/api/diary/analyze', analyzeRoutes);
 
     app.get('/', (req, res) => {
       res.json({ status: 'ok' });

--- a/utils/encryption.js
+++ b/utils/encryption.js
@@ -1,0 +1,21 @@
+const crypto = require('crypto');
+
+const algorithm = 'aes-256-cbc';
+const key = crypto.createHash('sha256').update(process.env.AES_SECRET || 'secret').digest();
+const iv = Buffer.alloc(16, 0);
+
+function encrypt(text) {
+  const cipher = crypto.createCipheriv(algorithm, key, iv);
+  let encrypted = cipher.update(text, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+  return encrypted;
+}
+
+function decrypt(encrypted) {
+  const decipher = crypto.createDecipheriv(algorithm, key, iv);
+  let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+  decrypted += decipher.final('utf8');
+  return decrypted;
+}
+
+module.exports = { encrypt, decrypt };


### PR DESCRIPTION
## Summary
- flesh out Node.js server with routes and Mongo models
- add encryption helper and .env example
- wire routes for user auth, diary CRUD, media upload, and analysis dummy

## Testing
- `npm test` *(fails: No test setup yet)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6885c3330e80832cb3c4a1d7cea3ba12